### PR TITLE
Changed from sys.argv to __file__

### DIFF
--- a/mangle/util.py
+++ b/mangle/util.py
@@ -14,10 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import sys
 import os.path
 
 
 def buildResPath(relative):
-    directory = os.path.split(sys.argv[0])[0]
+    directory = os.path.dirname(__file__)
     return os.path.join(directory, relative)


### PR DESCRIPTION
With `sys.path` the package depends on the fact that the `mangle.pyw` launcher is exactly one directory under the package. `__file__` on the other hand, is relative to the package, so it does not matter where the `mangle.pyw` file is or whether it even exists at all, thus making the package self-contained. This is useful when putting the package in `site-packages` and the launcher into `$PATH`.
