### PR TITLE
Add: do not split images that are not "double page"

### DIFF
--- a/mangle/convert.py
+++ b/mangle/convert.py
@@ -121,8 +121,18 @@ class DialogConvert(QtGui.QProgressDialog):
                 archive = self.archive
                 pdf = self.pdf
 
-                # For right page (if requested)
-                if(self.book.imageFlags & ImageFlags.Split):
+                
+                # Maybe the user ask for a split, but the picture is not a large one, so skip
+                # it but only for this picture
+                if (flags & ImageFlags.Split) or (flags & ImageFlags.SplitInverse):
+                    if not image.isSplitable(source):
+                        # remove split flags
+                        splitFlags= [ImageFlags.Split, ImageFlags.SplitInverse, ImageFlags.SplitRight, ImageFlags.SplitLeft]
+                        for f in splitFlags:
+                            flags &= ~f
+
+                # For right page (if requested in options and need for this image)
+                if(flags & ImageFlags.Split):
                     # New path based on modified index
                     target = os.path.join(self.bookPath, '%05d.png' % (index * 2 + 0))
                     self.convertAndSave(source, target, device, flags ^ ImageFlags.Split | ImageFlags.SplitRight, archive, pdf)
@@ -130,7 +140,7 @@ class DialogConvert(QtGui.QProgressDialog):
                     target = os.path.join(self.bookPath, '%05d.png' % (index * 2 + 1))
 
                 # For right page (if requested), but in inverted mode
-                if(self.book.imageFlags & ImageFlags.SplitInverse):
+                if(flags & ImageFlags.SplitInverse):
                     # New path based on modified index
                     target = os.path.join(self.bookPath, '%05d.png' % (index * 2 + 0))
                     self.convertAndSave(source, target, device, flags ^ ImageFlags.SplitInverse | ImageFlags.SplitLeft, archive, pdf)

--- a/mangle/image.py
+++ b/mangle/image.py
@@ -221,6 +221,18 @@ def saveImage(image, target):
         raise RuntimeError('Cannot write image file %s' % target)
 
 
+# Look if the image is more width than hight, if not, means
+# it's should not be split (like the front page of a manga,
+# when all the inner pages are double)
+def isSplitable(source):
+    image = loadImage(source)
+    try:
+        widthImg, heightImg = image.size
+        return  widthImg > heightImg
+    except IOError: 
+        raise RuntimeError('Cannot read image file %s' % source)
+
+
 def convertImage(source, target, device, flags):
     try:
         size, palette = KindleData.Profiles[device]


### PR DESCRIPTION
In some scan, the front page is a single page picture, when all the inner pages are double.

When ask for split (left,right and right,left mode), try to detect if the current image is double (by looking at width&height) and if not a double one (more large than height) then remove split flags for this specific image.

I did test in a scan that was getting errors (fron page slit) and now it's ok. I don't see any case that can be broken with this new logic, but other inputs are welcomed :+1: 

ps: if need I'll rebuild the exe ;)