### PR TITLE
Scale and Crop instead of Stretch

### DIFF
--- a/mangle/image.py
+++ b/mangle/image.py
@@ -24,7 +24,7 @@ class ImageFlags:
     Resize = 1 << 1
     Frame = 1 << 2
     Quantize = 1 << 3
-    Stretch = 1 << 4
+    ScaleCrop = 1 << 4
     SplitRightLeft = 1 << 5    # split right then left
     SplitRight = 1 << 6        # split only the right page
     SplitLeft = 1 << 7         # split only the left page
@@ -134,7 +134,7 @@ def quantizeImage(image, palette):
 
 
 @protect_bad_image
-def stretchImage(image, size):
+def scaleCropImage(image, size):
     return ImageOps.fit(image, size, Image.ANTIALIAS)
 
 
@@ -275,7 +275,7 @@ def convertImage(source, target, device, flags):
         image = orientImage(image, size)
     if flags & ImageFlags.Resize:
         image = resizeImage(image, size)
-    if flags & ImageFlags.Stretch:
+    if flags & ImageFlags.ScaleCrop:
         image = stretchImage(image, size)
     if flags & ImageFlags.Frame:
         image = frameImage(image, tuple(palette[:3]), tuple(palette[-3:]), size)

--- a/mangle/image.py
+++ b/mangle/image.py
@@ -16,7 +16,7 @@
 
 import os
 
-from PIL import Image, ImageDraw, ImageStat, ImageChops
+from PIL import Image, ImageDraw, ImageStat, ImageChops, ImageOps
 
 
 class ImageFlags:
@@ -135,9 +135,7 @@ def quantizeImage(image, palette):
 
 @protect_bad_image
 def stretchImage(image, size):
-    widthDev, heightDev = size
-
-    return image.resize((widthDev, heightDev), Image.ANTIALIAS)
+    return ImageOps.fit(image, size, Image.ANTIALIAS)
 
 
 @protect_bad_image

--- a/mangle/image.py
+++ b/mangle/image.py
@@ -276,7 +276,7 @@ def convertImage(source, target, device, flags):
     if flags & ImageFlags.Resize:
         image = resizeImage(image, size)
     if flags & ImageFlags.ScaleCrop:
-        image = stretchImage(image, size)
+        image = scaleCropImage(image, size)
     if flags & ImageFlags.Frame:
         image = frameImage(image, tuple(palette[:3]), tuple(palette[-3:]), size)
     if flags & ImageFlags.Quantize:

--- a/mangle/options.py
+++ b/mangle/options.py
@@ -43,7 +43,7 @@ class DialogOptions(QtGui.QDialog):
         self.checkboxOverwrite.setChecked(self.book.overwrite)
         self.checkboxOrient.setChecked(self.book.imageFlags & ImageFlags.Orient)
         self.checkboxResize.setChecked(self.book.imageFlags & ImageFlags.Resize)
-        self.checkboxStretch.setChecked(self.book.imageFlags & ImageFlags.Stretch)
+        self.checkboxScaleCrop.setChecked(self.book.imageFlags & ImageFlags.ScaleCrop)
         self.checkboxQuantize.setChecked(self.book.imageFlags & ImageFlags.Quantize)
         self.checkboxFrame.setChecked(self.book.imageFlags & ImageFlags.Frame)
 
@@ -62,8 +62,8 @@ class DialogOptions(QtGui.QDialog):
             imageFlags |= ImageFlags.Orient
         if self.checkboxResize.isChecked():
             imageFlags |= ImageFlags.Resize
-        if self.checkboxStretch.isChecked():
-            imageFlags |= ImageFlags.Stretch
+        if self.checkboxScaleCrop.isChecked():
+            imageFlags |= ImageFlags.ScaleCrop
         if self.checkboxQuantize.isChecked():
             imageFlags |= ImageFlags.Quantize
         if self.checkboxFrame.isChecked():

--- a/mangle/ui/options.ui
+++ b/mangle/ui/options.ui
@@ -217,7 +217,7 @@
       <item>
        <widget class="QRadioButton" name="checkboxStretch">
         <property name="text">
-         <string>Stretch images to fill the screen</string>
+         <string>Scale and crop images to fill the screen</string>
         </property>
        </widget>
       </item>

--- a/mangle/ui/options.ui
+++ b/mangle/ui/options.ui
@@ -215,7 +215,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QRadioButton" name="checkboxStretch">
+       <widget class="QRadioButton" name="checkboxScaleCrop">
         <property name="text">
          <string>Scale and crop images to fill the screen</string>
         </property>

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'bundle_files': 1,
         'includes': ['sip'],
         'packages': ['reportlab.pdfbase'],
-        'dll_excludes': ['w9xpopen.exe']
+        'dll_excludes': ['MSVCP90.dll', 'w9xpopen.exe']
     }},
     zipfile=None
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'bundle_files': 1,
         'includes': ['sip'],
         'packages': ['reportlab.pdfbase'],
-        'dll_excludes': ['MSVCP90.dll', 'w9xpopen.exe']
+        'dll_excludes': ['w9xpopen.exe']
     }},
     zipfile=None
 )


### PR DESCRIPTION
I think scaling and cropping to fill the screen makes more sense than stretching to fill as a use case.

Great when the source files are slightly skinnier than a kindle screen and can afford a little crop on the top and bottom!

Also makes text slightly bigger, which is nice on small screens. 

Solves issue #31 