### PR TITLE
adjust centering

### DIFF
--- a/mangle/image.py
+++ b/mangle/image.py
@@ -135,7 +135,9 @@ def quantizeImage(image, palette):
 
 @protect_bad_image
 def scaleCropImage(image, size):
-    return ImageOps.fit(image, size, Image.ANTIALIAS)
+    # crop only from top of images
+    # since dialogue is never near the top of images
+    return ImageOps.fit(image, size, Image.ANTIALIAS, centering=(0.5, 1.0))
 
 
 @protect_bad_image


### PR DESCRIPTION
For the CropScale function, it's smarter to crop from the top of the image, since dialogue is never near the top.

This makes reading with the navbar and not in fullscreen mode never cut off text near the bottom of a page due to the navbar taking up space!

This actually shows more text than just fitting to screen with borders.

![image](https://user-images.githubusercontent.com/20757319/113491330-c5cbe500-9484-11eb-9ab9-c191d8933fa3.jpeg)