### PR TITLE
Don't rotate if image smaller than device already

### DIFF
--- a/mangle/image.py
+++ b/mangle/image.py
@@ -174,6 +174,9 @@ def formatImage(image):
 def orientImage(image, size):
     widthDev, heightDev = size
     widthImg, heightImg = image.size
+    
+    if widthImg <= widthDev and heightImg <= heightDev:
+        return image
 
     if (widthImg > heightImg) != (widthDev > heightDev):
         return image.rotate(90, Image.BICUBIC, True)


### PR DESCRIPTION
Just a small nitpick, don't rotate images if the image is super small to begin with.