### PR TITLE
Don't crop 2 page spreads

### DIFF
--- a/mangle/image.py
+++ b/mangle/image.py
@@ -135,6 +135,13 @@ def quantizeImage(image, palette):
 
 @protect_bad_image
 def scaleCropImage(image, size):
+    widthDev, heightDev = size
+    widthImg, heightImg = image.size
+
+    # don't crop 2 page spreads.
+    if (float(widthImg) / float(heightImg)) > (float(widthDev) / float(heightDev)):
+        return resizeImage(image, size)
+    
     return ImageOps.fit(image, size, Image.ANTIALIAS)
 
 
@@ -184,11 +191,12 @@ def orientImage(image, size):
 # by inverting colors, and asking a bounder box ^^
 @protect_bad_image
 def autoCropImage(image):
+    w, h = image.size
     try:
         x0, y0, xend, yend = ImageChops.invert(image).getbbox()
     except TypeError: # bad image, specific to chops
         return image
-    image = image.crop((x0, y0, xend, yend))
+    image = image.crop((0, y0, w, yend))
 
     return image
 

--- a/mangle/image.py
+++ b/mangle/image.py
@@ -137,9 +137,12 @@ def quantizeImage(image, palette):
 def scaleCropImage(image, size):
     widthDev, heightDev = size
     widthImg, heightImg = image.size
+    
+    imgRatio = float(widthImg) / float(heightImg)
+    devRatio = float(widthDev) / float(heightDev)
 
     # don't crop 2 page spreads.
-    if (float(widthImg) / float(heightImg)) > (float(widthDev) / float(heightDev)):
+    if imgRatio > devRatio:
         return resizeImage(image, size)
     
     return ImageOps.fit(image, size, Image.ANTIALIAS)

--- a/mangle/image.py
+++ b/mangle/image.py
@@ -191,12 +191,11 @@ def orientImage(image, size):
 # by inverting colors, and asking a bounder box ^^
 @protect_bad_image
 def autoCropImage(image):
-    w, h = image.size
     try:
         x0, y0, xend, yend = ImageChops.invert(image).getbbox()
     except TypeError: # bad image, specific to chops
         return image
-    image = image.crop((0, y0, w, yend))
+    image = image.crop((x0, y0, xend, yend))
 
     return image
 

--- a/mangle/ui/options.ui
+++ b/mangle/ui/options.ui
@@ -217,7 +217,7 @@
       <item>
        <widget class="QRadioButton" name="checkboxScaleCrop">
         <property name="text">
-         <string>Scale and crop images to fill the screen</string>
+         <string>Scale and crop images to fill screen width</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
I realize now that cropping rotated two page spreads to fill the screen is a bad idea. The aspect ratio of two page spreads would result in way too much cropping.

This fixes it by reverting to default behavior in those cases, since rotated two page spreads are much wider than normal pages.